### PR TITLE
Point to releases for dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Math",
         "repositoryURL": "https://github.com/dn-m/Math",
         "state": {
-          "branch": "master",
+          "branch": null,
           "revision": "075ebb5a934251ed7acbe4feace925ed7e322d0f",
-          "version": null
+          "version": "0.6.0"
         }
       },
       {
@@ -23,9 +23,9 @@
         "package": "Structure",
         "repositoryURL": "https://github.com/dn-m/Structure",
         "state": {
-          "branch": "master",
+          "branch": null,
           "revision": "11e920b1b883fe169c5ebb58e6489c0f28e9ad90",
-          "version": null
+          "version": "0.20.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
         .library(name: "Timeline", targets: ["Timeline"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/dn-m/Structure", .branch("master")),
-        .package(url: "https://github.com/dn-m/Math", .branch("master"))
+        .package(url: "https://github.com/dn-m/Structure", from: "0.20.0"),
+        .package(url: "https://github.com/dn-m/Math", from: "0.6.0")
     ],
     targets: [
 


### PR DESCRIPTION
To ensure that downstream usage is clean, point to releases of dependencies, rather than the `master` branch.